### PR TITLE
Nick/lobby no auth test fix

### DIFF
--- a/tests/src/TestBCLobby.cpp
+++ b/tests/src/TestBCLobby.cpp
@@ -119,10 +119,10 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 		}
 
 		// TearDown
-		TestResult tr;
-		wrapper->logout(true, &tr);
+		TestResult tr2;
+		wrapper->logout(true, &tr2);
 
-		tr.run(bc, true);
+		tr2.run(bc, true);
 
 		bc->resetCommunication();
 
@@ -194,10 +194,10 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 		}
 
 		// TearDown
-		TestResult tr;
-		wrapper->logout(true, &tr);
+		TestResult tr2;
+		wrapper->logout(true, &tr2);
 
-		tr.run(bc, true);
+		tr2.run(bc, true);
 
 		bc->resetCommunication();
 

--- a/tests/src/TestBCLobby.cpp
+++ b/tests/src/TestBCLobby.cpp
@@ -118,7 +118,14 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 			std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		}
 
-		wrapper->logout(true, nullptr);
+		// TearDown
+		TestResult tr;
+		wrapper->logout(true, &tr);
+
+		tr.run(bc, true);
+
+		bc->resetCommunication();
+
 		delete wrapper;
 	});
 
@@ -187,7 +194,14 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 		}
 
 		// TearDown
-		wrapper->logout(true, nullptr);
+		TestResult tr;
+		wrapper->logout(true, &tr);
+
+		tr.run(bc, true);
+
+		bc->resetCommunication();
+
+		delete wrapper;
 	});
 
 	// Join threads

--- a/tests/src/TestBCLobby.cpp
+++ b/tests/src/TestBCLobby.cpp
@@ -118,8 +118,7 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 			std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		}
 
-		// TearDown
-		Logout();
+		wrapper->logout(true, nullptr);
 		delete wrapper;
 	});
 
@@ -188,7 +187,7 @@ TEST_F(TestBCLobbyNoAuth, CreateAndJoinLobby)
 		}
 
 		// TearDown
-		Logout();
+		wrapper->logout(true, nullptr);
 	});
 
 	// Join threads


### PR DESCRIPTION
Fixed issue where a couple brainCloud sessions within threads were not calling the correct logout function (was calling a logout function outside of the thread in a brainCloud wrapper instance that had no authenticated session instead)

Tested here: https://vmjenkins.bitheads.com/view/Client_UnitTests/job/bitHeads_BrainCloud_Client_UnitTest_C++_Win32_develop_internal/1283/console