### PR TITLE
BCLOUD-9470

### DIFF
--- a/src/BrainCloudPushNotification.cpp
+++ b/src/BrainCloudPushNotification.cpp
@@ -13,6 +13,7 @@
 #include "braincloud/internal/StringUtil.h"
 #include "braincloud/internal/JsonUtil.h"
 #include "braincloud/Platform.h"
+#include <reason_codes.h>
 
 namespace BrainCloud
 {
@@ -37,6 +38,31 @@ namespace BrainCloud
 
 	void BrainCloudPushNotification::registerPushNotificationDeviceToken(const Platform & in_platform, const char * in_token, IServerCallback * in_callback)
 	{
+		// Validate token
+    	if (in_token == nullptr || strlen(in_token) == 0)
+    	{
+    	    if (in_callback)
+        	{
+        	    int statusCode = 400; // Bad Request
+        	    int reasonCode = INVALID_DEVICE_TOKEN; // Invalid Device Token
+			
+        	    // Build error JSON
+        	    std::string errorJson = 
+        	        "{\"status\":" + std::to_string(statusCode) +
+        	        ",\"reason_code\":" + std::to_string(reasonCode) +
+        	        ",\"message\":\"Invalid device token: " + in_token + " \"}";
+			
+        	    in_callback->serverError(
+        	        ServiceName::PushNotification,
+        	        ServiceOperation::Register,
+        	        statusCode,
+        	        reasonCode,
+        	        errorJson
+        	    );
+        	}
+    	    return;
+    	}
+
 		Json::Value message;
 		message[OperationParam::PushNotificationRegisterParamDeviceType.getValue()] = in_platform.toString().c_str();
 		message[OperationParam::PushNotificationRegisterParamDeviceToken.getValue()] = in_token;


### PR DESCRIPTION
Client Library update - Update the client libs to Catch the case when the app requests notifications and the user denies it, resulting in an "empty token" being saved into the place that stores the notification token - C++