### PR TITLE
[BCLOUD-11730] Add Oculus as Gettable Platform

### DIFF
--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -6,7 +6,7 @@ namespace BrainCloud
     const Platform & Platform::AppleTVOS = Platform("APPLE_TV_OS");
     const Platform & Platform::BlackBerry = Platform("BB");
     const Platform & Platform::Facebook = Platform("FB");
-    const Platform & Platform::Oculus = Platform("Oculus");
+    const Platform & Platform::Oculus = Platform("OCULUS");
     const Platform & Platform::GooglePlayAndroid = Platform("ANG");
     const Platform & Platform::iOS = Platform("IOS");
     const Platform & Platform::Linux = Platform("LINUX");

--- a/src/android/AndroidDevice.cpp
+++ b/src/android/AndroidDevice.cpp
@@ -14,9 +14,78 @@ namespace BrainCloud
 {
     namespace Device
     {
+        static bool detectOculusDevice()
+        {
+            if (!appEnv) return false;
+
+            // -------------------------------------------------
+            // Check PackageManager for Oculus / Meta services
+            // -------------------------------------------------
+            jclass jcActivityThread = appEnv->FindClass("android/app/ActivityThread");
+            jmethodID jmCurrentApp = appEnv->GetStaticMethodID(
+                jcActivityThread, "currentApplication", "()Landroid/app/Application;");
+
+            jobject joApp = appEnv->CallStaticObjectMethod(jcActivityThread, jmCurrentApp);
+            if (!joApp) return false;
+
+            jclass jcContext = appEnv->GetObjectClass(joApp);
+            jmethodID jmGetPM = appEnv->GetMethodID(
+                jcContext, "getPackageManager", "()Landroid/content/pm/PackageManager;");
+            jobject joPM = appEnv->CallObjectMethod(joApp, jmGetPM);
+
+            jclass jcPM = appEnv->GetObjectClass(joPM);
+            jmethodID jmGetPkgInfo = appEnv->GetMethodID(
+                jcPM, "getPackageInfo",
+                "(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;");
+
+            auto hasPackage = [&](const char* pkg) -> bool
+                {
+                    jstring jPkg = appEnv->NewStringUTF(pkg);
+                    appEnv->CallObjectMethod(joPM, jmGetPkgInfo, jPkg, 0);
+                    appEnv->DeleteLocalRef(jPkg);
+
+                    if (appEnv->ExceptionCheck())
+                    {
+                        appEnv->ExceptionClear();
+                        return false;
+                    }
+                    return true;
+                };
+
+            if (hasPackage("com.oculus.vrservice") ||
+                hasPackage("com.oculus.systemdriver") ||
+                hasPackage("com.meta.xr.vrservice"))
+            {
+                return true;
+            }
+
+            // -------------------------------------------------
+            // Check VR head tracking feature
+            // -------------------------------------------------
+            jmethodID jmHasFeature = appEnv->GetMethodID(
+                jcPM, "hasSystemFeature", "(Ljava/lang/String;)Z");
+
+            jstring vrFeature =
+                appEnv->NewStringUTF("android.hardware.vr.headtracking");
+
+            jboolean hasVR = appEnv->CallBooleanMethod(joPM, jmHasFeature, vrFeature);
+            appEnv->DeleteLocalRef(vrFeature);
+
+            return hasVR == JNI_TRUE;
+        }
+
         const std::string& getPlatformName()
         {
-            return PLATFORM_NAME;
+            static std::string platformName;
+            static bool initialized = false;
+
+            if (!initialized)
+            {
+                initialized = true;
+                platformName = detectOculusDevice() ? "OCULUS" : "ANG";
+            }
+
+            return platformName;
         }
 
         void getLocale(float* out_timezoneOffset, std::string* out_languageCode, std::string* out_countryCode) {

--- a/src/android/AndroidDevice.cpp
+++ b/src/android/AndroidDevice.cpp
@@ -4,7 +4,11 @@
 #include <jni.h>
 #include <time.h>
 
+#if TARGET_OCULUS
+static const std::string PLATFORM_NAME("OCULUS");
+#else
 static const std::string PLATFORM_NAME("ANG");
+#endif
 
 namespace BrainCloud
 {

--- a/src/marmalade/IwDevice.cpp
+++ b/src/marmalade/IwDevice.cpp
@@ -20,8 +20,8 @@ namespace BrainCloud
                     return Platform::GooglePlayAndroid.toString();
                 case S3E_OS_ID_QNX: // playbook
                     return Platform::BlackBerry.toString();
-                case S3E_OS_ID_ROKU: // TODO - add Roku platform!!!
-                    return Platform::GooglePlayAndroid.toString();
+                case S3E_OS_ID_ROKU:
+                    return Platform::Roku.toString();
                 case S3E_OS_ID_WP8:
                 case S3E_OS_ID_WP81:
                     return Platform::WindowsPhone.toString();


### PR DESCRIPTION
[BCLOUD-11730](https://bitheads.atlassian.net/browse/BCLOUD-11730)

Added Oculus as Gettable Platform on Android devices using the `TARGET_OCULUS` define.