### PR TITLE
Fl/bcloud 12199 disable ability to request rtt&relay connect requests

### DIFF
--- a/include/braincloud/BrainCloudClient.h
+++ b/include/braincloud/BrainCloudClient.h
@@ -363,6 +363,10 @@ namespace BrainCloud
 		 */
 		bool isInitialized();
 
+		/// Returns if killswitch was activated.
+		/// @return true if killswitch is activated.
+		bool isKillswitchEngaged();
+
 		/**
 		 * If true, tells the comms library to immediately retry a packet
 		 * when an error is received.

--- a/include/braincloud/internal/IBrainCloudComms.h
+++ b/include/braincloud/internal/IBrainCloudComms.h
@@ -104,6 +104,7 @@ namespace BrainCloud
 		void enableLogging(bool shouldEnable);
 		bool isInitialized();
 		bool isAuthenticated();
+		bool isKillswitchEngaged();
 		void setAuthenticated();
 
 		//compression
@@ -195,7 +196,7 @@ namespace BrainCloud
 		int32_t _reasonCodeCache;
 		std::string _statusMessageCache;
 
-		bool _killSwitchEngaged;
+		bool _killSwitchEngaged = false;
 		int32_t _killSwitchErrorCount;
 		std::string _killSwitchService;
 		std::string _killSwitchOperation;

--- a/src/BrainCloudClient.cpp
+++ b/src/BrainCloudClient.cpp
@@ -404,6 +404,11 @@ namespace BrainCloud
         return _brainCloudComms->isInitialized() && _rttComms->isInitialized() && _relayComms->isInitialized();
     }
 
+    bool BrainCloudClient::isKillswitchEngaged()
+    {
+        return _brainCloudComms->isKillswitchEngaged();
+    }
+
     void BrainCloudClient::setImmediateRetryOnError(bool value)
     {
         _brainCloudComms->setImmediateRetryOnError(value);

--- a/src/IBrainCloudComms.cpp
+++ b/src/IBrainCloudComms.cpp
@@ -92,6 +92,11 @@ namespace BrainCloud {
 		_isAuthenticated = true;
 	}
 
+	bool IBrainCloudComms::isKillswitchEngaged()
+	{
+		return _killSwitchEngaged;
+	}
+
 	void IBrainCloudComms::setHeartbeatInterval(int milliseconds)
 	{
 		_heartbeatInterval = milliseconds;

--- a/src/RTTComms.cpp
+++ b/src/RTTComms.cpp
@@ -152,7 +152,9 @@ namespace BrainCloud
         }
         else if(!_client->isAuthenticated() || _client->isKillswitchEngaged())
         {
+#if RTTCOMMS_LOG_EVERY_METHODS
             std::cout << "VERBOSE: RTT: EnableRTT called before calling authentication request. Disabling RTT." << std::endl;
+#endif
             callback->rttConnectFailure("RTT: EnableRTT called before calling authentication request. Disabling RTT.");
             return;
         }

--- a/src/RTTComms.cpp
+++ b/src/RTTComms.cpp
@@ -150,7 +150,13 @@ namespace BrainCloud
         {
             return;
         }
-        else
+        else if(!_client->isAuthenticated() || _client->isKillswitchEngaged())
+        {
+            std::cout << "VERBOSE: RTT: EnableRTT called before calling authentication request. Disabling RTT." << std::endl;
+            callback->rttConnectFailure("RTT: EnableRTT called before calling authentication request. Disabling RTT.");
+            return;
+        }
+        else 
         {               
             _connectCallback = callback;
             _useWebSocket = useWebSocket;

--- a/src/RTTComms.cpp
+++ b/src/RTTComms.cpp
@@ -156,7 +156,6 @@ namespace BrainCloud
             std::cout << "VERBOSE: RTT: EnableRTT called before calling authentication request. Disabling RTT." << std::endl;
 #endif
             callback->rttConnectFailure("RTT: EnableRTT called before calling authentication request. Disabling RTT.");
-            return;
         }
         else 
         {               

--- a/src/RelayComms.cpp
+++ b/src/RelayComms.cpp
@@ -127,6 +127,13 @@ namespace BrainCloud
 
     void RelayComms::connect(eRelayConnectionType connectionType, const std::string& host, int port, const std::string& passcode, const std::string& lobbyId, IRelayConnectCallback* callback)
     {
+        if(!m_client->isAuthenticated() || m_client->isKillswitchEngaged())
+        {
+            printf("Relay: Connect called before calling authentication request. Disabling Relay.");
+            queueErrorEvent("Relay: Connect called before calling authentication request. Disabling Relay.");
+            return;
+        }
+
         if (m_isSocketConnected)
         {
             socketCleanup();

--- a/tests/src/TestBCAuth.cpp
+++ b/tests/src/TestBCAuth.cpp
@@ -404,3 +404,11 @@ TEST_F (TestBCAuth, RTTRequestWithNoAuthSession)
     m_bc->getRTTService()->enableRTT(&trRTT);
     EXPECT_FALSE(m_bc->getRTTService()->getRTTEnabled());
 }
+
+TEST_F(TestBCAuth, RelayRequestWithNoAuthSession)
+{
+    TestResult trRelay;
+    
+    m_bc->getRelayService()->connect(BrainCloud::eRelayConnectionType::WS, std::string(""), 0, std::string(""), std::string(""), &trRelay);
+    EXPECT_FALSE(m_bc->getRelayService()->isConnected());
+}

--- a/tests/src/TestBCAuth.cpp
+++ b/tests/src/TestBCAuth.cpp
@@ -396,3 +396,11 @@ TEST_F(TestBCAuth, LongSession)
     delete userAWrapper;
     delete userBWrapper;
 }
+
+TEST_F (TestBCAuth, RTTRequestWithNoAuthSession)
+{
+    TestResult trRTT;
+    
+    m_bc->getRTTService()->enableRTT(&trRTT);
+    EXPECT_FALSE(m_bc->getRTTService()->getRTTEnabled());
+}

--- a/tests/src/TestBCRTTComms.cpp
+++ b/tests/src/TestBCRTTComms.cpp
@@ -248,16 +248,3 @@ TEST_F(TestBCRTTComms, RTTEventCallback)
     // Wait 60sec, creating lobby can take time
     EXPECT_TRUE(rttCallback.receivedCallback());
 }
-
-TEST_F (TestBCRTTComms, RTTRequestWithNoAuthSession)
-{
-    TestResult tr;
-    //FL: Not sure how to make this test suite skip authenticating in set up without creating a whole new test suite. So logging out to get rid of our auth session.
-    m_bc->getPlayerStateService()->logout(&tr);
-    tr.run(m_bc);
-    
-    m_bc->getRTTService()->enableRTT(&tr);
-    tr.run(m_bc);
-    EXPECT_FALSE(m_bc->getRTTService()->getRTTEnabled());
-}
-

--- a/tests/src/TestBCRTTComms.cpp
+++ b/tests/src/TestBCRTTComms.cpp
@@ -3,7 +3,7 @@
 #include "braincloud/reason_codes.h"
 #include "braincloud/http_codes.h"
 #include "braincloud/IRTTCallback.h"
-
+#include "braincloud/BrainCloudRTT.h";
 #include <chrono>
 #include <thread>
 
@@ -247,5 +247,17 @@ TEST_F(TestBCRTTComms, RTTEventCallback)
     // Now check if we get the chat message
     // Wait 60sec, creating lobby can take time
     EXPECT_TRUE(rttCallback.receivedCallback());
+}
+
+TEST_F (TestBCRTTComms, RTTRequestWithNoAuthSession)
+{
+    TestResult tr;
+    //FL: Not sure how to make this test suite skip authenticating in set up without creating a whole new test suite. So logging out to get rid of our auth session.
+    m_bc->getPlayerStateService()->logout(&tr);
+    tr.run(m_bc);
+    
+    m_bc->getRTTService()->enableRTT(&tr);
+    tr.run(m_bc);
+    EXPECT_FALSE(m_bc->getRTTService()->getRTTEnabled());
 }
 

--- a/tests/src/TestBCRTTComms.cpp
+++ b/tests/src/TestBCRTTComms.cpp
@@ -3,7 +3,7 @@
 #include "braincloud/reason_codes.h"
 #include "braincloud/http_codes.h"
 #include "braincloud/IRTTCallback.h"
-#include "braincloud/BrainCloudRTT.h";
+
 #include <chrono>
 #include <thread>
 
@@ -248,3 +248,4 @@ TEST_F(TestBCRTTComms, RTTEventCallback)
     // Wait 60sec, creating lobby can take time
     EXPECT_TRUE(rttCallback.receivedCallback());
 }
+

--- a/tests/src/TestResult.cpp
+++ b/tests/src/TestResult.cpp
@@ -253,6 +253,29 @@ void TestResult::rttConnectFailure(const std::string& errorMessage)
     }
 }
 
+void TestResult::relayConnectSuccess(const std::string& jsonResponse)
+{
+    m_response.clear();
+    m_result = true;
+    --m_apiCountExpected;
+    if (m_apiCountExpected <= 0)
+    {
+        m_done = true;
+    }
+}
+
+void TestResult::relayConnectFailure(const std::string& errorMessage)
+{
+    m_statusMessage = errorMessage;
+
+    m_result = false;
+    --m_apiCountExpected;
+    if (m_apiCountExpected <= 0)
+    {
+        m_done = true;
+    }
+}
+
 void TestResult::serverCallback(ServiceName serviceName, ServiceOperation serviceOperation, std::string const & jsonData)
 {
     Json::Value value;

--- a/tests/src/TestResult.h
+++ b/tests/src/TestResult.h
@@ -4,10 +4,11 @@
 #include <stdlib.h>
 #include "gtest/gtest.h"
 #include "braincloud/BrainCloudClient.h"
+#include "brainCloud/IRelayConnectCallback.h"
 
 using namespace BrainCloud;
 
-class TestResult : public IServerCallback, public IGlobalErrorCallback, public INetworkErrorCallback, public IRTTConnectCallback
+class TestResult : public IServerCallback, public IGlobalErrorCallback, public INetworkErrorCallback, public IRTTConnectCallback, public IRelayConnectCallback
 {
 public:
     bool m_done;
@@ -35,6 +36,8 @@ public:
     virtual void serverError( ServiceName serviceName, ServiceOperation serviceOperation, int statusCode, int reasonCode, const std::string & statusMessage);
 	virtual void rttConnectSuccess();
 	virtual void rttConnectFailure(const std::string& errorMessage);
+    virtual void relayConnectSuccess(const std::string& jsonResponse);
+    virtual void relayConnectFailure(const std::string& errorMessage);
     
     virtual void globalError( ServiceName serviceName, ServiceOperation serviceOperation, int statusCode, int reasonCode, const std::string & jsonError);
     


### PR DESCRIPTION
Test Results:  
```
[Compression disabled]
RTT: EnableRTT called before calling authentication request. Disabling RTT.[       OK ] TestBCAuth.RTTRequestWithNoAuthSession (2 ms)
[ RUN      ] TestBCAuth.RelayRequestWithNoAuthSession

 [Compression disabled]
Relay: Connect called before calling authentication request. Disabling Relay.[       OK ] TestBCAuth.RelayRequestWithNoAuthSession (30 ms)
[----------] 21 tests from TestBCAuth (16845 ms total)

[----------] Global test environment tear-down
```