### PR TITLE
BCLOUD-12771   Update CPP - RoomServer Examples to accept Pre Launch Ready

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,12 @@ endif()
 # Sockets
 if (USE_LIBWEBSOCKETS)
     list(APPEND OS_SPECIFIC_INCS
-            "include/braincloud/internal/DefaultWebSocket.h")
-    list(APPEND OS_SPECIFIC_SRCS "src/DefaultWebSocket.cpp")
+            "include/braincloud/internal/DefaultWebSocket.h"
+            "include/braincloud/internal/IRelayWSSocket.h"
+            "include/braincloud/internal/DefaultRelayWSSocket.h")
+    list(APPEND OS_SPECIFIC_SRCS
+            "src/DefaultWebSocket.cpp"
+            "src/DefaultRelayWSSocket.cpp")
 endif()
 if (WIN32)
     list(APPEND OS_SPECIFIC_SRCS "src/win/Win32TCPSocket.cpp")
@@ -322,6 +326,7 @@ add_library(brainCloud STATIC
         include/braincloud/internal/IRelaySocket.h
         include/braincloud/internal/IRelayTCPSocket.h
         include/braincloud/internal/IRelayUDPSocket.h
+        include/braincloud/internal/IRelayWSSocket.h
         include/braincloud/internal/ITCPSocket.h
         include/braincloud/internal/JsonUtil.h
         include/braincloud/internal/Mutex.h

--- a/include/braincloud/internal/DefaultRelayWSSocket.h
+++ b/include/braincloud/internal/DefaultRelayWSSocket.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#if __APPLE__
+    #include "TargetConditionals.h"
+#endif
+
+#if (!defined(TARGET_OS_WATCH) || TARGET_OS_WATCH == 0)
+
+#include "braincloud/internal/IRelayWSSocket.h"
+
+#include <libwebsockets.h>
+#include <lws_config.h>
+
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace BrainCloud
+{
+    class DefaultRelayWSSocket : public IRelayWSSocket
+    {
+    public:
+        static int libWebsocketsCallback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in, size_t len);
+
+        virtual ~DefaultRelayWSSocket();
+
+        virtual bool isConnected() override;
+        virtual bool isValid() override;
+        virtual void updateConnection() override;
+        virtual void send(const uint8_t* pData, int size) override;
+        virtual const uint8_t* peek(int& size) override;
+        virtual void close() override;
+
+    protected:
+        friend class IRelayWSSocket;
+
+        DefaultRelayWSSocket(const std::string& address, int port, int maxPacketSize, bool useSSL);
+
+    private:
+        void onClose();
+        void onError(const char* msg);
+        void onConnect();
+        void onRecv(const uint8_t* buffer, int len);
+        void processSendQueue();
+
+        // State (protected by _mutex)
+        bool _isValid;
+        bool _isConnecting;
+
+        // Send side
+        std::mutex _mutex;
+        std::queue<std::vector<uint8_t>> _sendQueue;
+        std::vector<uint8_t> _sendBuffer;
+        std::thread _updateThread;
+
+        // Receive side (protected by _recvMutex)
+        std::mutex _recvMutex;
+        std::queue<std::vector<uint8_t>> _recvQueue;
+        std::vector<uint8_t> _currentPacket;  // Holds the packet returned by peek()
+
+        // libwebsockets
+        struct lws_context* _pLwsContext;
+        struct lws* _pLws;
+    };
+};
+
+#endif /* TARGET_OS_WATCH */

--- a/include/braincloud/internal/IRelayWSSocket.h
+++ b/include/braincloud/internal/IRelayWSSocket.h
@@ -1,0 +1,21 @@
+#ifndef _IRELAYWSSOCKET_H_
+#define _IRELAYWSSOCKET_H_
+
+#include "IRelaySocket.h"
+#include <string>
+
+namespace BrainCloud
+{
+    class IRelayWSSocket : public IRelaySocket
+    {
+    public:
+        static IRelayWSSocket* create(const std::string& address, int port, int maxPacketSize = 1400, bool useSSL = false);
+
+        virtual ~IRelayWSSocket() {}
+
+    protected:
+        IRelayWSSocket() {}
+    };
+};
+
+#endif /* _IRELAYWSSOCKET_H_ */

--- a/src/DefaultRelayWSSocket.cpp
+++ b/src/DefaultRelayWSSocket.cpp
@@ -1,0 +1,285 @@
+// Copyright 2026 bitHeads, Inc. All Rights Reserved.
+#if (!defined(TARGET_OS_WATCH) || TARGET_OS_WATCH == 0)
+
+#include "braincloud/internal/DefaultRelayWSSocket.h"
+
+#include <iostream>
+
+#define RELAY_WS_MAX_PAYLOAD (64 * 1024)
+
+static std::mutex relayWsContextMutex;
+
+namespace BrainCloud
+{
+    static struct lws_protocols relayWsProtocols[] = {
+        {
+            "bcrs",
+            &DefaultRelayWSSocket::libWebsocketsCallback,
+            0,
+            RELAY_WS_MAX_PAYLOAD,
+            0, NULL, 0
+        },
+        { NULL, NULL, 0, 0 } /* terminator */
+    };
+
+    IRelayWSSocket* IRelayWSSocket::create(const std::string& address, int port, int maxPacketSize, bool useSSL)
+    {
+        return new DefaultRelayWSSocket(address, port, maxPacketSize, useSSL);
+    }
+
+    DefaultRelayWSSocket::~DefaultRelayWSSocket()
+    {
+        close();
+    }
+
+    DefaultRelayWSSocket::DefaultRelayWSSocket(const std::string& address, int port, int maxPacketSize, bool useSSL)
+        : _isValid(false)
+        , _isConnecting(true)
+        , _pLwsContext(NULL)
+        , _pLws(NULL)
+    {
+        // Create lws context
+        {
+            struct lws_context_creation_info info;
+            memset(&info, 0, sizeof(info));
+
+            info.port = CONTEXT_PORT_NO_LISTEN;
+            info.protocols = relayWsProtocols;
+            info.gid = -1;
+            info.uid = -1;
+            info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+            if (useSSL)
+            {
+                #if (LWS_LIBRARY_VERSION_MAJOR >= 4) && !defined(BC_SSL_ALLOW_SELFSIGNED) && defined(LWS_WITH_MBEDTLS)
+                    info.client_ssl_ca_filepath = CACERTS_FILE_PATH;
+                #endif
+            }
+
+            std::unique_lock<std::mutex> lock(relayWsContextMutex);
+            _pLwsContext = lws_create_context(&info);
+            if (!_pLwsContext)
+            {
+                std::cout << "Relay WS: Failed to create websocket context" << std::endl;
+                _isConnecting = false;
+                return;
+            }
+        }
+
+        // Create connection
+        {
+            struct lws_client_connect_info connectInfo;
+            memset(&connectInfo, 0, sizeof(connectInfo));
+
+            connectInfo.context = _pLwsContext;
+            connectInfo.address = address.c_str();
+            connectInfo.port = port;
+            if (useSSL)
+            {
+                connectInfo.ssl_connection =
+                    LCCSCF_USE_SSL
+#if defined(BC_SSL_ALLOW_SELFSIGNED)
+                    | LCCSCF_ALLOW_SELFSIGNED
+#endif
+                    ;
+            }
+            else
+            {
+                connectInfo.ssl_connection = 0;
+            }
+            connectInfo.path = "/";
+            connectInfo.host = address.c_str();
+            connectInfo.origin = address.c_str();
+            connectInfo.protocol = relayWsProtocols[0].name;
+            connectInfo.ietf_version_or_minus_one = -1;
+            connectInfo.userdata = this;
+
+            _pLws = lws_client_connect_via_info(&connectInfo);
+            if (!_pLws)
+            {
+                std::cout << "Relay WS: Failed to create websocket client" << std::endl;
+                _isConnecting = false;
+                return;
+            }
+
+            // Start background service thread
+            _updateThread = std::thread([this]()
+            {
+                _mutex.lock();
+                while (_isConnecting || _isValid)
+                {
+                    _mutex.unlock();
+                    lws_service(_pLwsContext, 0);
+                    lws_callback_on_writable_all_protocol(_pLwsContext, &relayWsProtocols[0]);
+                    _mutex.lock();
+                }
+                _mutex.unlock();
+            });
+        }
+    }
+
+    int DefaultRelayWSSocket::libWebsocketsCallback(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in, size_t len)
+    {
+        DefaultRelayWSSocket* pSocket = (DefaultRelayWSSocket*)lws_wsi_user(wsi);
+
+        switch (reason)
+        {
+            case LWS_CALLBACK_WSI_DESTROY:
+            case LWS_CALLBACK_CLOSED_CLIENT_HTTP:
+            case LWS_CALLBACK_CLOSED:
+            case LWS_CALLBACK_CLIENT_CLOSED:
+            {
+                if (!pSocket) return -1;
+                pSocket->onClose();
+                break;
+            }
+            case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
+            {
+                if (!pSocket) return -1;
+                pSocket->onError(in ? (const char*)in : "connection error");
+                break;
+            }
+            case LWS_CALLBACK_CLIENT_ESTABLISHED:
+            {
+                if (!pSocket) return -1;
+                pSocket->onConnect();
+                break;
+            }
+            case LWS_CALLBACK_CLIENT_RECEIVE:
+            {
+                if (!pSocket || !in) return -1;
+                pSocket->onRecv((const uint8_t*)in, (int)len);
+                break;
+            }
+            case LWS_CALLBACK_CLIENT_WRITEABLE:
+            {
+                if (!pSocket) return -1;
+                pSocket->processSendQueue();
+                break;
+            }
+            default:
+                break;
+        }
+
+        return 0;
+    }
+
+    bool DefaultRelayWSSocket::isConnected()
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        return !_isConnecting && _isValid;
+    }
+
+    bool DefaultRelayWSSocket::isValid()
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        return _isConnecting || _isValid;
+    }
+
+    void DefaultRelayWSSocket::updateConnection()
+    {
+        // lws background thread drives the connection asynchronously
+    }
+
+    void DefaultRelayWSSocket::send(const uint8_t* pData, int size)
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if (!_isValid && !_isConnecting) return;
+        _sendQueue.push(std::vector<uint8_t>(pData, pData + size));
+    }
+
+    void DefaultRelayWSSocket::processSendQueue()
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        while (!_sendQueue.empty())
+        {
+            const auto& packet = _sendQueue.front();
+            _sendBuffer.resize(LWS_PRE + packet.size());
+            memcpy(_sendBuffer.data() + LWS_PRE, packet.data(), packet.size());
+            lws_write(_pLws, _sendBuffer.data() + LWS_PRE, packet.size(), LWS_WRITE_BINARY);
+            _sendQueue.pop();
+        }
+    }
+
+    const uint8_t* DefaultRelayWSSocket::peek(int& size)
+    {
+        size = 0;
+        std::unique_lock<std::mutex> lock(_recvMutex);
+        if (_recvQueue.empty()) return nullptr;
+        _currentPacket = std::move(_recvQueue.front());
+        _recvQueue.pop();
+        size = (int)_currentPacket.size();
+        return _currentPacket.data();
+    }
+
+    void DefaultRelayWSSocket::close()
+    {
+        // Signal thread to stop
+        {
+            std::unique_lock<std::mutex> lock(_mutex);
+            while (!_sendQueue.empty()) _sendQueue.pop();
+            _isValid = false;
+            _isConnecting = false;
+        }
+
+        // Unblock lws_service() so the update thread can exit
+        if (_pLwsContext)
+        {
+            lws_cancel_service(_pLwsContext);
+        }
+
+        // Join update thread
+        if (_updateThread.joinable())
+        {
+            _updateThread.join();
+        }
+
+        // Kill the lws connection
+        if (_pLws)
+        {
+            lws_set_timeout(_pLws, NO_PENDING_TIMEOUT, LWS_TO_KILL_SYNC);
+            _pLws = NULL;
+        }
+
+        // Destroy context
+        if (_pLwsContext)
+        {
+            std::unique_lock<std::mutex> lock(relayWsContextMutex);
+            lws_context_destroy(_pLwsContext);
+            _pLwsContext = NULL;
+        }
+    }
+
+    void DefaultRelayWSSocket::onClose()
+    {
+        std::cout << "Relay WS: closed" << std::endl;
+        std::unique_lock<std::mutex> lock(_mutex);
+        _isValid = false;
+        _isConnecting = false;
+        _pLws = NULL;
+    }
+
+    void DefaultRelayWSSocket::onError(const char* msg)
+    {
+        std::cout << "Relay WS error: " << msg << std::endl;
+        std::unique_lock<std::mutex> lock(_mutex);
+        _isValid = false;
+        _isConnecting = false;
+        _pLws = NULL;
+    }
+
+    void DefaultRelayWSSocket::onConnect()
+    {
+        std::cout << "Relay WS: connected" << std::endl;
+        std::unique_lock<std::mutex> lock(_mutex);
+        _isValid = true;
+        _isConnecting = false;
+    }
+
+    void DefaultRelayWSSocket::onRecv(const uint8_t* buffer, int len)
+    {
+        std::unique_lock<std::mutex> lock(_recvMutex);
+        _recvQueue.push(std::vector<uint8_t>(buffer, buffer + len));
+    }
+};
+
+#endif /* TARGET_OS_WATCH */

--- a/src/RelayComms.cpp
+++ b/src/RelayComms.cpp
@@ -8,6 +8,7 @@
 #include "braincloud/internal/IRelayUDPSocket.h"
 #if (!defined(TARGET_OS_WATCH) || TARGET_OS_WATCH == 0)
 #include "braincloud/internal/IWebSocket.h"
+#include "braincloud/internal/IRelayWSSocket.h"
 #endif
 #include "braincloud/internal/RelayComms.h"
 
@@ -177,6 +178,18 @@ namespace BrainCloud
                 m_lastRecvTime = std::chrono::system_clock::now();
                 break;
             }
+#if (!defined(TARGET_OS_WATCH) || TARGET_OS_WATCH == 0)
+            case eRelayConnectionType::WS:
+            {
+                m_pSocket = IRelayWSSocket::create(host, port, MAX_PACKET_SIZE, false);
+                break;
+            }
+            case eRelayConnectionType::WSS:
+            {
+                m_pSocket = IRelayWSSocket::create(host, port, MAX_PACKET_SIZE, true);
+                break;
+            }
+#endif
             default:
             {
                 socketCleanup();
@@ -895,6 +908,23 @@ namespace BrainCloud
         {
             if (m_pSocket->isConnected())
             {
+                // If the socket just connected (e.g., WS background thread connected before
+                // this runCallbacks tick), send the handshake CONNECT packet now.
+                if (!m_isSocketConnected)
+                {
+                    m_isSocketConnected = true;
+                    if (m_loggingEnabled)
+                    {
+                        std::cout << "RelayComms: Relay Socket Connected" << std::endl;
+                    }
+                    send(CL2RS_CONNECT, buildConnectionRequest());
+                    if (m_connectionType == eRelayConnectionType::UDP)
+                    {
+                        m_resendConnectRequest = true;
+                        m_lastConnectResendTime = now;
+                    }
+                }
+
                 // Peek messages
                 int packetSize;
                 const uint8_t* pPacketData;

--- a/src/RelayComms.cpp
+++ b/src/RelayComms.cpp
@@ -334,6 +334,7 @@ namespace BrainCloud
     void RelayComms::send(const uint8_t* data, int size, uint64_t playerMask, bool reliable, bool ordered, eRelayChannel channel)
     {
         if (!isConnected()) return;
+        if (playerMask == 0) return;
         if (size > 1024)
         {
             socketCleanup();


### PR DESCRIPTION
This is required to get Relay Test App up and running Gamelift and other Web Socket Server Protocol, including brainCloud Relay Server.

DefaultRelayWSSocket::close() — lws_cancel_service before join() to prevent blocking when the socket closes mid-handshake
RelayComms::runCallbacks() — send CL2RS_CONNECT on first connected tick even if the WS background thread connected before the first runCallbacks call (was why WS never advanced to gameplay)
RelayComms::send() — if (playerMask == 0) return to guard the infinite while ((mask & 1) == 0) loop (was the freeze when no players were selected in the mask)